### PR TITLE
Feature/INT-1060 PR Trial Run

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -78,13 +78,6 @@ jobs:
       with:
         category: "/language:java"
 
-    - name: 🔐 Run Additional Security Scan (Trivy)
-      uses: aquasecurity/trivy-action@master
-      with:
-        scan-type: 'fs'
-        scan-ref: '.'
-        format: 'table'
-
     - name: 🏗️ Build Validation
       run: mvn clean package -DskipTests
 


### PR DESCRIPTION
<div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This PR streamlines the CI/CD workflow by removing the Trivy security scan step from the configuration file. The change eliminates redundant scanning operations, resulting in a cleaner and more efficient CI pipeline.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 1
-->
</div>